### PR TITLE
Fix OpenAI base URL configuration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,10 @@ import os
 from fastapi import FastAPI
 from openai import OpenAI
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = OpenAI(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url="https://api.openai.com/v1",
+)
 model = os.getenv("OPENAI_MODEL", "gpt-4.1-mini")
 
 app = FastAPI()

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -45,6 +45,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     res.json({ status: "ok", timestamp: new Date().toISOString() });
   });
 
+  app.get("/health/openai", (_req: Request, res: Response) => {
+    res.json({ ok: true, model: process.env.OPENAI_MODEL ?? null });
+  });
+
   // OpenAI health check endpoint
   app.get("/api/health/openai", (req: Request, res: Response) => {
     const health = openAIHealth();

--- a/server/utils/ai-utils.ts
+++ b/server/utils/ai-utils.ts
@@ -1,8 +1,13 @@
 import OpenAI from "openai";
 
+if (!process.env.OPENAI_API_KEY && !process.env.OPENAI_API_KEY2) {
+  console.error("Missing OPENAI_API_KEY");
+}
+
 // Support both old and new API keys
-const openai = new OpenAI({ 
-  apiKey: process.env.OPENAI_API_KEY2 || process.env.OPENAI_API_KEY 
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY2 || process.env.OPENAI_API_KEY,
+  baseURL: "https://api.openai.com/v1",
 });
 
 export interface AIResponse {


### PR DESCRIPTION
## Summary
- set explicit https://api.openai.com/v1 base URL for both Node and FastAPI OpenAI clients and log when API keys are missing
- expose a lightweight /health/openai Express route reporting the configured model

Fix OpenAI baseURL to api.openai.com/v1; remove accidental DB host usage; add health check.

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c8484549908322b53d2cab19baf879