### PR TITLE
feat: AI‑only valuation with expert prompt + strict JSON schema

### DIFF
--- a/backend/ai-utils.ts
+++ b/backend/ai-utils.ts
@@ -1,0 +1,8 @@
+import OpenAI from "openai";
+
+export const OPENAI_MODEL = process.env.OPENAI_MODEL || "gpt-4.1-mini";
+
+export const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+  baseURL: "https://api.openai.com/v1"
+});

--- a/backend/prompts/valuation.ts
+++ b/backend/prompts/valuation.ts
@@ -1,0 +1,20 @@
+export const VALUATION_SYSTEM_PROMPT = `
+You are a senior marine valuation specialist for luxury yachts and sportfish vessels.
+Your job is to estimate fair‑market value ranges and explain the drivers with clear, concise reasoning.
+
+Principles:
+- Be precise, conservative, and data‑driven. Prefer recent market behavior and realistic sell prices over aspirational asks.
+- Consider: year, make, model, LOA/beam/draft, engines (brand/hp/quantity), engine hours & service history, refits/upgrades, condition, layout, equipment (stabilizers/seakeeper, electronics), region/seasonality, charter history, survey readiness, and time‑to‑sell.
+- Assume South Florida comps by default unless location is provided.
+- If info is missing or uncertain, state the uncertainty briefly but still produce a best‑effort estimate.
+- No markdown, no prose outside JSON when asked for JSON. Do not invent fake listings or cite unverifiable comps.
+`;
+
+// Optional: a tiny helper to build a compact user payload
+export function buildValuationUserPayload(input: Record<string, any>) {
+  return {
+    instruction:
+      "Estimate fair‑market valuation strictly from these fields. OUTPUT STRICT JSON ONLY with keys: {valuation_low:number, valuation_mid:number, valuation_high:number, narrative:string, assumptions:string[]}. No extra keys.",
+    fields: input
+  };
+}

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -1,0 +1,8 @@
+export type ValuationResult = {
+  valuation_low: number | null;
+  valuation_mid: number | null;
+  valuation_high: number | null;
+  narrative: string | null;
+  assumptions: string[] | null;
+  inputs_echo: Record<string, any>;
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,18 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { openai, OPENAI_MODEL } from "../backend/ai-utils";
+
+console.log("OpenAI baseURL =", (openai as any).baseURL || "default");
+console.log("OPENAI key present =", !!process.env.OPENAI_API_KEY);
+if (((openai as any).baseURL || "").includes("dpg-")) {
+  throw new Error("Misconfigured OpenAI baseURL (points to Postgres host).");
+}
 
 const app = express();
+app.get("/health/openai", (_req, res) => {
+  res.json({ key: !!process.env.OPENAI_API_KEY, model: OPENAI_MODEL });
+});
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 


### PR DESCRIPTION
## Summary
- configure a REST-only OpenAI client with env-driven model selection
- add valuation system prompt and types to enforce strict JSON output
- replace the valuation endpoint with the AI-only handler (no fallback equations) plus startup guard and health route logging

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c85431ba8083228b01c47ca1106d14