### PR TITLE
Remove modalities parameter from valuation response

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,7 +26,6 @@ export async function postValuation(req: Request, res: Response) {
         { role: "system", content: VALUATION_SYSTEM_PROMPT },
         { role: "user", content: JSON.stringify(buildValuationUserPayload(payload)) }
       ],
-      modalities: ["text"],
       text: { format: "json_object" },
       temperature: 0.2
     } as any);


### PR DESCRIPTION
## Summary
- remove the `modalities` option from the valuation response request while keeping the JSON object text output configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8adcf89308322bb0cff87f73c608b