### PR TITLE
Update valuation response format

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,7 +26,7 @@ export async function postValuation(req: Request, res: Response) {
         { role: "system", content: VALUATION_SYSTEM_PROMPT },
         { role: "user", content: JSON.stringify(buildValuationUserPayload(payload)) }
       ],
-      text: { format: "json_object" },
+      text: { format: "json" },
       temperature: 0.2
     } as any);
 


### PR DESCRIPTION
## Summary
- update the OpenAI Responses request for the valuation endpoint to use `text: { format: "json" }`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8af63dec483229d57e447ce5f10c6