### PR TITLE
Update valuation response format to json_object

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,7 +26,7 @@ export async function postValuation(req: Request, res: Response) {
         { role: "system", content: VALUATION_SYSTEM_PROMPT },
         { role: "user", content: JSON.stringify(buildValuationUserPayload(payload)) }
       ],
-      text: { format: "json" },
+      text: { format: { type: "json_object" } },
       temperature: 0.2
     } as any);
 


### PR DESCRIPTION
## Summary
- update the valuation OpenAI Responses API call to request a `json_object` formatted text output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b16a1c988322b17fe003a28507ed