### PR TITLE
chore(api): deterministic valuation call (temp0+seed) for stable AI-only outputs

### DIFF
--- a/server/utils/ai-utils.ts
+++ b/server/utils/ai-utils.ts
@@ -197,6 +197,11 @@ export async function callOpenAI(
         model,
         messages,
         ...options,
+        temperature: 0,
+        top_p: 1,
+        n: 1,
+        seed: 7,
+        response_format: { type: "json_object" },
         timeout: 15000 // 15 second timeout
       });
 


### PR DESCRIPTION
## Summary
- enforce deterministic chat completions fallback settings for valuation flows using temperature 0, seed 7, and JSON response formatting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c98da735808322a44253384e1aeecb