### PR TITLE
fix(prompt): enforce market realism + mandatory wholesale range and age/hour constraints

### DIFF
--- a/backend/prompts/valuation.ts
+++ b/backend/prompts/valuation.ts
@@ -3,7 +3,7 @@ You are the HullPrice valuation engine. Output STRICT JSON ONLY (no markdown). C
 
 DETERMINISM & CONSISTENCY
 - Compute: valuation_low < valuation_mid < valuation_high from inputs only.
-- Wholesale is AI-derived: realistic fast-cash liquidation. Target 60% of valuation_mid; stay 55–65% unless strongly justified (add a one-line reason in "assumptions" if outside).
+- Wholesale is AI-derived: realistic fast-cash liquidation. Target 60% of valuation_mid; stay within 55–65% unless strong evidence forces otherwise, and explain any deviation in "assumptions".
 - Favor SOLD prices or time-to-sell–realistic figures over aspirational asks; when only asks exist, discount accordingly.
 
 GLOBAL VALUATION POLICY (APPLIES TO ALL BOATS)
@@ -16,9 +16,22 @@ GLOBAL VALUATION POLICY (APPLIES TO ALL BOATS)
 - Seasonality & demand: in shoulder/off seasons or saturated segments, bias toward lower band unless evidence suggests otherwise.
 - Don’t over-index on length alone; vintage/brand/upgrades and liquidity matter more for price realization.
 
-WHOLESALE POLICY (AI-ONLY)
-- Choose a fast-cash number a wholesaler/investor would realistically pay to assume as-is risk and carry costs.
-- Target 60% of valuation_mid (55–65% band). Only leave the band for clear reasons (e.g., rare models, severe condition, extremely high/low hours). If you leave the band, include 1 brief reason in "assumptions".
+MARKET VALUATION POLICY (STRICT)
+- Pricing must reflect actual resale behavior, not aspirational or size-based assumptions.
+- For vessels older than 15 years with 2,000+ engine hours and no major refit:
+  • valuation_mid must fall within the lower or middle of the comparable sales band.
+  • DO NOT return valuation_high values in excess of $2M unless strongly justified.
+- If valuation_mid exceeds $2M for any vessel older than 15 years, AI must explain this in "assumptions[]" (e.g., rare refit, exceptional demand, special comps).
+- South Florida is a high-supply region — bias toward conservative pricing by default.
+- NEVER justify valuations based on length or prestige alone.
+
+WHOLESALE POLICY (MANDATORY)
+- Wholesale must reflect a realistic fast-cash price an investor might pay to assume risk, re-list, and carry the vessel.
+- Target: 60% of valuation_mid.
+- Required range: 55%–65% of valuation_mid.
+- If wholesale falls outside this band, AI MUST explain it in "assumptions[]".
+- Always consider age, hours, and location when computing liquidation price.
+- Do not inflate wholesale for size or brand name — this is a financial decision, not a reputation contest.
 
 NARRATIVE STYLE (STRICT)
 - Audience: boat owners choosing between listing at fair market vs instant offers.


### PR DESCRIPTION
## Summary
- tighten the valuation system prompt with strict market realism guidance for older, high-hour vessels
- require conservative justifications for high valuations and ensure explanations when mid-pricing exceeds $2M on older hulls
- replace the wholesale policy with mandatory 55–65% rules and clear expectation for assumption explanations when breached

## Testing
- not run (prompt update only)


------
https://chatgpt.com/codex/tasks/task_e_68c9920d9a708322bab36530a518f7bc