### PR TITLE
feat: polished valuation experience with confidence badge

### DIFF
--- a/backend/prompts/valuation.ts
+++ b/backend/prompts/valuation.ts
@@ -33,17 +33,15 @@ WHOLESALE POLICY (MANDATORY)
 - Always consider age, hours, and location when computing liquidation price.
 - Do not inflate wholesale for size or brand name — this is a financial decision, not a reputation contest.
 
-NARRATIVE STYLE (STRICT)
-- Audience: boat owners choosing between listing at fair market vs instant offers.
-- Tone: positive, professional, transparent; lead with opportunity; avoid fear language.
-- Do NOT use: "reduces value", "limits pricing", "issues", "concerning".
-- Prefer: "influences pricing", "typical for age", "room to modernize".
-- 110–130 words, 3–5 complete sentences, one paragraph, US English.
-- Include these exact tokens in the paragraph with thousands separators:
-  - "Estimated Market Range: $<low>–$<high>"
-  - "Most Likely: $<mid>"
-  - "Wholesale: ~$<wholesale>"
-  - "Confidence: <Low|Medium|High>"
+Narrative Style (strict):
+- Write one paragraph (110–130 words) tailored to a boat owner.
+- Lead with a high-level opportunity or insight (not by restating inputs).
+- Explain valuation drivers in plain language: comps, condition, hours, region, demand.
+- Use phrases like “recent comps show…”, “this segment typically trades…”, “buyers often factor…”.
+- End the paragraph with the token line:
+  "Estimated Market Range: $<low>–$<high>. Most Likely: $<mid>. Wholesale: ~$<wholesale>. Confidence: <Low|Medium|High>."
+- Positive, professional, transparent. Avoid “reduces value / limits pricing / issues / concerning”.
+- Do not paste numeric examples or reuse example values.
 
 STRICT JSON SHAPE (only these keys):
 {

--- a/client/src/components/ConfidenceBadge.tsx
+++ b/client/src/components/ConfidenceBadge.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+type Level = "Low" | "Medium" | "High";
+
+export function ConfidenceBadge({ level }: { level?: string | null }) {
+  const lv = (level || "Medium") as Level;
+  const color =
+    lv === "High" ? "bg-green-100 text-green-800"
+    : lv === "Low" ? "bg-amber-100 text-amber-800"
+    : "bg-sky-100 text-sky-800";
+
+  const text =
+    lv === "High"
+      ? "High: recent comps and clear market signals."
+      : lv === "Low"
+      ? "Low: limited comps or variable market signals — verify before listing."
+      : "Medium: reasonable comps available, but pricing can vary with equipment, timing, and presentation.";
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${color}`}>
+        Confidence: {lv}
+      </span>
+      <span className="group relative cursor-help text-xs text-slate-500">
+        What’s this?
+        <span className="invisible group-hover:visible absolute z-10 mt-2 w-72 rounded-md bg-white p-3 text-left text-[11px] leading-5 text-slate-700 shadow-lg ring-1 ring-black/5">
+          {text}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/client/src/components/MetricCard.tsx
+++ b/client/src/components/MetricCard.tsx
@@ -1,7 +1,10 @@
-export function MetricCard({label,value}: {label: string, value?: number}){
-  const fmt=(n: number | undefined)=> n?.toLocaleString?.("en-US",{style:"currency",currency:"USD"}) ?? "—";
+export function MetricCard({ label, value }: { label: string; value?: number | null }) {
+  const fmt = (n: number | null | undefined) =>
+    typeof n === "number"
+      ? n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 })
+      : "—";
   return (
-    <div className="hp-card hp-metric">
+    <div className="hp-card hp-metric rounded-2xl border border-slate-200 bg-white shadow-sm">
       <div className="hp-cap">{label}</div>
       <div className="hp-val">{fmt(value)}</div>
     </div>

--- a/client/src/components/ValuationNarrative.tsx
+++ b/client/src/components/ValuationNarrative.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <div className="text-sm font-semibold text-slate-700">{children}</div>;
+}
+
+export function ValuationNarrative({
+  narrative,
+  low, mid, high, wholesale
+}: {
+  narrative?: string | null;
+  low?: number | null;
+  mid?: number | null;
+  high?: number | null;
+  wholesale?: number | null;
+}) {
+  // Fallback-safe formatter; no math
+  const fmt = (n?: number | null) =>
+    typeof n === "number" ? n.toLocaleString("en-US", { maximumFractionDigits: 0 }) : "—";
+
+  // If the AI already included the token line, we just show the paragraph.
+  // Below we also repeat the tokens in a clean summary row for scannability.
+  return (
+    <div className="space-y-3">
+      <SectionTitle>Valuation Summary</SectionTitle>
+      <p className="rounded-2xl border border-slate-200 bg-white p-4 leading-7 text-slate-700">
+        {narrative || "Your valuation summary will appear here."}
+      </p>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+          <div className="text-xs text-slate-500">Estimated Range</div>
+          <div className="text-sm font-semibold text-slate-800">${fmt(low)}–${fmt(high)}</div>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+          <div className="text-xs text-slate-500">Most Likely</div>
+          <div className="text-sm font-semibold text-slate-800">${fmt(mid)}</div>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+          <div className="text-xs text-slate-500">Wholesale (Fast Cash)</div>
+          <div className="text-sm font-semibold text-slate-800">~${fmt(wholesale)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/boat-form.tsx
+++ b/client/src/components/boat-form.tsx
@@ -219,37 +219,23 @@ export default function BoatForm({
           throw new Error(message);
         }
 
-        const floor10k = (value: number | null) =>
-          typeof value === "number" && Number.isFinite(value)
-            ? Math.floor(value / 10000) * 10000
+        const lowValue = normalizedResult.valuation_low;
+        const midValue = normalizedResult.valuation_mid;
+        const highValue = normalizedResult.valuation_high;
+        const wholesaleValue = normalizedResult.wholesale;
+
+        const confidenceMatch =
+          typeof normalizedResult.narrative === "string"
+            ? /Confidence:\s*(Low|Medium|High)/.exec(normalizedResult.narrative)
             : null;
-
-        const midFallbackValue =
-          normalizedResult.valuation_low !== null && normalizedResult.valuation_high !== null
-            ? Math.round((normalizedResult.valuation_low + normalizedResult.valuation_high) / 2)
-            : null;
-
-        const midBaseCandidate = normalizedResult.valuation_mid ?? midFallbackValue;
-        const mostLikelyValue =
-          midBaseCandidate ??
-          normalizedResult.valuation_high ??
-          normalizedResult.valuation_low ??
-          0;
-        const midBaseValue = midBaseCandidate ?? mostLikelyValue;
-        const lowValue = normalizedResult.valuation_low ?? mostLikelyValue;
-        const highValue = normalizedResult.valuation_high ?? mostLikelyValue;
-
-        const derivedWholesale =
-          normalizedResult.wholesale ?? floor10k(midBaseValue * 0.60);
-
-        const wholesaleValue = derivedWholesale ?? floor10k(mostLikelyValue * 0.60) ?? 0;
+        const confidence = confidenceMatch?.[1] ?? "Medium";
         const estimate = {
           id: generateId(),
           low: lowValue,
-          mostLikely: mostLikelyValue,
+          mostLikely: midValue,
           high: highValue,
           wholesale: wholesaleValue,
-          confidence: "Medium",
+          confidence,
           narrative: normalizedResult.narrative ?? "",
           comps: [],
           isPremiumLead: false,

--- a/client/src/components/valuation-results.tsx
+++ b/client/src/components/valuation-results.tsx
@@ -1,5 +1,7 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { ConfidenceBadge } from "@/components/ConfidenceBadge";
+import { ValuationNarrative } from "@/components/ValuationNarrative";
 
 interface ValuationData {
   lead: {
@@ -19,10 +21,10 @@ interface ValuationData {
   };
   estimate: {
     id: string;
-    low: number;
-    mostLikely: number;
-    high: number;
-    wholesale: number;
+    low: number | null;
+    mostLikely: number | null;
+    high: number | null;
+    wholesale: number | null;
     confidence: string;
     narrative: string;
     comps: Array<{
@@ -45,6 +47,12 @@ interface ValuationResultsProps {
 
 export default function ValuationResults({ data, onCallJames, onEmailReport }: ValuationResultsProps) {
   const { lead, vessel, estimate } = data;
+  const confidenceMatch = /Confidence:\s*(Low|Medium|High)/.exec(estimate.narrative ?? "");
+  const confidenceLevel = confidenceMatch?.[1] ?? estimate.confidence ?? "Medium";
+  const fmtCurrency = (value: number | null) =>
+    typeof value === "number"
+      ? value.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 })
+      : "—";
 
   return (
     <div className="fade-in">
@@ -59,11 +67,7 @@ export default function ValuationResults({ data, onCallJames, onEmailReport }: V
               <p className="text-blue-100">Based on current market conditions and comparable sales</p>
             </div>
             <div className="text-right">
-              <div className="bg-white bg-opacity-20 rounded-lg px-3 py-1">
-                <span className="text-sm font-medium" data-testid="text-confidence">
-                  Confidence: {estimate.confidence}
-                </span>
-              </div>
+              <ConfidenceBadge level={confidenceLevel} />
             </div>
           </div>
         </div>
@@ -129,27 +133,27 @@ export default function ValuationResults({ data, onCallJames, onEmailReport }: V
                 <div className="text-center p-4 bg-primary bg-opacity-10 rounded-lg">
                   <div className="text-sm text-white font-medium mb-1">Estimated Value</div>
                   <div className="text-3xl font-bold text-white" data-testid="text-most-likely-value">
-                    ${estimate.mostLikely.toLocaleString()}
+                    {fmtCurrency(estimate.mostLikely)}
                   </div>
                 </div>
                 <div className="grid grid-cols-2 gap-4 text-sm">
                   <div className="text-center p-3 bg-muted rounded-lg">
                     <div className="text-muted-foreground mb-1">Low</div>
                     <div className="font-semibold" data-testid="text-low-value">
-                      ${estimate.low.toLocaleString()}
+                      {fmtCurrency(estimate.low)}
                     </div>
                   </div>
                   <div className="text-center p-3 bg-muted rounded-lg">
                     <div className="text-muted-foreground mb-1">High</div>
                     <div className="font-semibold" data-testid="text-high-value">
-                      ${estimate.high.toLocaleString()}
+                      {fmtCurrency(estimate.high)}
                     </div>
                   </div>
                 </div>
                 <div className="text-center p-3 bg-secondary rounded-lg">
                   <div className="text-sm text-muted-foreground mb-1">Wholesale Estimate</div>
                   <div className="font-semibold text-foreground" data-testid="text-wholesale-value">
-                    ${estimate.wholesale.toLocaleString()}
+                    {fmtCurrency(estimate.wholesale)}
                   </div>
                 </div>
               </div>
@@ -160,11 +164,13 @@ export default function ValuationResults({ data, onCallJames, onEmailReport }: V
         {/* Market Analysis */}
         <CardContent className="p-6 border-b">
           <h3 className="text-lg font-semibold text-foreground mb-4">Market Analysis</h3>
-          <div className="prose prose-sm max-w-none">
-            <p className="text-muted-foreground leading-relaxed" data-testid="text-narrative">
-              {estimate.narrative}
-            </p>
-          </div>
+          <ValuationNarrative
+            narrative={estimate.narrative}
+            low={estimate.low}
+            mid={estimate.mostLikely}
+            high={estimate.high}
+            wholesale={estimate.wholesale}
+          />
         </CardContent>
 
         {/* Comparable Sales */}

--- a/client/src/pages/boat-valuation.tsx
+++ b/client/src/pages/boat-valuation.tsx
@@ -2,15 +2,14 @@ import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import BoatForm from "@/components/boat-form";
-import ValuationResults from "@/components/valuation-results";
-import ProgressIndicator from "@/components/progress-indicator";
 import { useToast } from "@/hooks/use-toast";
 import { useUTMTracking } from "@/hooks/use-utm-tracking";
 import HullPriceLogo from "@/components/HullPriceLogo";
 import { Stepper } from "@/components/Stepper";
 import { MetricCard } from "@/components/MetricCard";
-import { Confidence } from "@/components/Confidence";
 import { Loader } from "@/components/Loader";
+import { ConfidenceBadge } from "@/components/ConfidenceBadge";
+import { ValuationNarrative } from "@/components/ValuationNarrative";
 
 interface ValuationData {
   lead: {
@@ -30,10 +29,10 @@ interface ValuationData {
   };
   estimate: {
     id: string;
-    low: number;
-    mostLikely: number;
-    high: number;
-    wholesale: number;
+    low: number | null;
+    mostLikely: number | null;
+    high: number | null;
+    wholesale: number | null;
     confidence: string;
     narrative: string;
     comps: Array<{
@@ -53,6 +52,10 @@ export default function BoatValuation() {
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
   const utmParams = useUTMTracking();
+
+  const narrativeText = valuationData?.estimate?.narrative ?? "";
+  const confidenceMatch = /Confidence:\s*(Low|Medium|High)/.exec(narrativeText);
+  const confidenceLevel = confidenceMatch?.[1] ?? valuationData?.estimate?.confidence ?? "Medium";
 
   const handleValuationComplete = (data: ValuationData) => {
     setValuationData(data);
@@ -94,14 +97,24 @@ export default function BoatValuation() {
         ) : (
           valuationData && (
             <section className="hp-card" style={{padding:18, marginTop:16}}>
-              <div className="hp-grid-2">
-                <MetricCard label="Low" value={valuationData.estimate.low}/>
-                <MetricCard label="Most Likely" value={valuationData.estimate.mostLikely}/>
-                <MetricCard label="High" value={valuationData.estimate.high}/>
-                <MetricCard label="Wholesale" value={valuationData.estimate.wholesale}/>
+              <div className="space-y-4 md:space-y-6">
+                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <ConfidenceBadge level={confidenceLevel} />
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  <MetricCard label="Low" value={valuationData.estimate.low} />
+                  <MetricCard label="Most Likely" value={valuationData.estimate.mostLikely} />
+                  <MetricCard label="High" value={valuationData.estimate.high} />
+                  <MetricCard label="Wholesale" value={valuationData.estimate.wholesale} />
+                </div>
+                <ValuationNarrative
+                  narrative={valuationData.estimate.narrative}
+                  low={valuationData.estimate.low}
+                  mid={valuationData.estimate.mostLikely}
+                  high={valuationData.estimate.high}
+                  wholesale={valuationData.estimate.wholesale}
+                />
               </div>
-              <Confidence level={valuationData.estimate.confidence as "Low" | "Medium" | "High"}/>
-              <p style={{marginTop:12, color:"#334155", whiteSpace:"pre-wrap"}}>{valuationData.estimate.narrative}</p>
             </section>
           )
         )}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,10 @@ export async function postValuation(req: Request, res: Response) {
       ai = {};
     }
 
+    if (ai && typeof ai.narrative === "string") {
+      ai.narrative = ai.narrative.replace(/\s+/g, " ").trim();
+    }
+
     // Scrub banned phrases
     if (ai && typeof ai.narrative === "string") {
       ai.narrative = ai.narrative


### PR DESCRIPTION
## Summary
- refresh the valuation system prompt with the owner-focused narrative guidance and normalize whitespace in AI responses
- add reusable ConfidenceBadge and ValuationNarrative components and wire them into the valuation results view with updated spacing and stat card styling
- rely on AI-provided valuation figures throughout the client flow while parsing confidence from the narrative for display

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c999377c94832293691f8ab587ac59