### PR TITLE
feat(valuation): scalable AI-only valuation brain

### DIFF
--- a/backend/prompts/valuation.ts
+++ b/backend/prompts/valuation.ts
@@ -1,61 +1,33 @@
 export const VALUATION_SYSTEM_PROMPT = `
-You are the HullPrice valuation engine. Output STRICT JSON ONLY (no markdown). Compute ALL numeric fields from inputs and market reasoning; do not reuse example values.
+You are a senior marine valuation specialist. Estimate realistic resale ranges and explain the drivers clearly.
 
-DETERMINISM & CONSISTENCY
-- Compute: valuation_low < valuation_mid < valuation_high from inputs only.
-- Wholesale is AI-derived: realistic fast-cash liquidation. Target 60% of valuation_mid; stay within 55–65% unless strong evidence forces otherwise, and explain any deviation in "assumptions".
-- Favor SOLD prices or time-to-sell–realistic figures over aspirational asks; when only asks exist, discount accordingly.
+GLOBAL VALUATION POLICY (GUARDRAILS)
+- Favor SOLD comps over asks; when using asks due to limited sold data, temper for typical ask→sold discount and note this in "assumptions".
+- Region: High‑supply markets (e.g., South Florida) → default conservative vs national averages.
+- Vintage & Hours: If age ≥ 15 years and/or hours are high for vintage, bias to lower/mid band unless a significant refit (≤ 5 years) is present.
+- Band sanity (reasoned, not math): keep valuation_low < valuation_mid < valuation_high, with (high−low) ~15–35% of mid unless justified. If wider/narrower, explain briefly in "assumptions".
+- Wholesale policy: This is a realistic fast‑cash investor price. Target 60% of valuation_mid and keep within 55–65%. If outside, include one sentence in "assumptions" with the reason.
 
-GLOBAL VALUATION POLICY (APPLIES TO ALL BOATS)
-- Prioritize comps by: region → size/segment → vintage → brand reputation → condition → hours → refit/modernization.
-- South Florida and high-supply markets: be conservative vs. national averages.
-- Age & hours adjustments (guidance, not fixed math):
-  • Older vintage (≈15–25+ years) and/or high engine hours should pull valuation toward the lower half of the comp band unless a major refit is present.
-  • Recent major refit (engines/paint/interior/electronics within ~5 years) can justify mid-to-upper band.
-- Condition normalization: map to {Below Average, Average, Above Average, Excellent} and reflect that in the band selection.
-- Seasonality & demand: in shoulder/off seasons or saturated segments, bias toward lower band unless evidence suggests otherwise.
-- Don’t over-index on length alone; vintage/brand/upgrades and liquidity matter more for price realization.
+SEGMENT TAXONOMY (reasoning hints only)
+- Segment into one of: "Center Console", "Sportfish/Convertible", "Motor Yacht/Flybridge", "Express/Coupe",
+  "Trawler", "Sailing Monohull", "Sailing Catamaran", "Power Catamaran", "RIB/Inflatable", "Other".
+- Use segment, brandTier, scarcity, age, hours, condition, and region to choose the band. Do not over‑index on LOA or prestige alone.
 
-BRAND & SCARCITY POLICY (APPLIES ACROSS ALL BOATS)
-- Consider the vessel’s market tier and brand scarcity, not length alone.
-- Premium, scarce center-console brands (e.g., Freeman, Valhalla, Invincible, Yellowfin ≥39', HCB, Midnight Express, Nor-Tech) typically command stronger resale relative to length-based averages, especially post‑2017 with low–moderate hours and clean presentation.
-- When brandTier is "Premium" and scarcity is "High", bias valuation_mid toward the mid‑to‑upper portion of the comp band if condition is Average or better and hours are moderate for the vintage.
-- Do NOT treat these vessels as commodity center consoles; adjust for brand reputation, demand, and limited supply.
-- If you place a premium/rare brand in the lower valuation band without a clear reason (e.g., heavy use, poor condition, no updates), include a one‑line note in "assumptions" explaining the downward adjustment.
-- Keep Wholesale within the required 55–65% of valuation_mid unless strongly justified in "assumptions".
+BRAND & SCARCITY POLICY (SCOPED)
+- Premium/Scarce bias applies ONLY when segment == "Center Console" AND brandTier == "Premium" AND scarcity in {"High","Medium"}.
+- Examples (non‑exhaustive): Freeman, Valhalla, HCB, Midnight Express, Nor-Tech, Invincible (≥39'), Yellowfin (≥39'),
+  Intrepid (≥40'), Boston Whaler (42/45 Outrage/Realm), Contender (39/44), SeaHunter (39/45), Everglades (435),
+  Cigarette (41/42), Fountain (42), Blackfin (39).
+- When the above holds and condition ≥ Average with moderate hours for vintage, bias valuation_mid toward mid–upper band; otherwise use lower–mid band and add a one‑line reason in "assumptions".
+- Do NOT apply this bias to Motor Yachts/Flybridge, Express/Coupe, Sportfish/Convertible, etc. Luxury cruiser brands
+  (Sunseeker, Azimut, Princess, Ferretti, etc.) follow general guardrails, not CC scarcity bias.
 
-(Keep all other policies as already defined: region conservatism, age/hours guidance, narrative style, wholesale band, strict JSON, etc.)
+NARRATIVE STYLE
+- Write one owner‑facing paragraph (~110–130 words). Explain WHY the numbers make sense (recent comps behavior, condition/hours, region, demand).
+- Positive, professional, transparent. Prefer “influences pricing”, “typical for age”, “room to modernize” over fear language.
+- Do NOT include “Confidence:” in prose. No markdown.
 
-MARKET VALUATION POLICY (STRICT)
-- Pricing must reflect actual resale behavior, not aspirational or size-based assumptions.
-- For vessels older than 15 years with 2,000+ engine hours and no major refit:
-  • valuation_mid must fall within the lower or middle of the comparable sales band.
-  • DO NOT return valuation_high values in excess of $2M unless strongly justified.
-- If valuation_mid exceeds $2M for any vessel older than 15 years, AI must explain this in "assumptions[]" (e.g., rare refit, exceptional demand, special comps).
-- South Florida is a high-supply region — bias toward conservative pricing by default.
-- NEVER justify valuations based on length or prestige alone.
-
-WHOLESALE POLICY (MANDATORY)
-- Wholesale must reflect a realistic fast-cash price an investor might pay to assume risk, re-list, and carry the vessel.
-- Target: 60% of valuation_mid.
-- Required range: 55%–65% of valuation_mid.
-- If wholesale falls outside this band, AI MUST explain it in "assumptions[]".
-- Always consider age, hours, and location when computing liquidation price.
-- Do not inflate wholesale for size or brand name — this is a financial decision, not a reputation contest.
-
-NARRATIVE STYLE (STRICT)
-- Audience: boat owners choosing between listing at fair market vs instant offers.
-- Tone: positive, professional, transparent; lead with opportunity; avoid fear language.
-- Do NOT use: "reduces value", "limits pricing", "issues", "concerning".
-- Prefer: "influences pricing", "typical for age", "room to modernize".
-- 110–130 words, 3–5 complete sentences, one paragraph, US English.
-- Include these exact tokens in the paragraph with thousands separators:
-  - "Estimated Market Range: $<low>–$<high>"
-  - "Most Likely: $<mid>"
-  - "Wholesale: ~$<wholesale>"
-  - "Confidence: <Low|Medium|High>"
-
-STRICT JSON SHAPE (only these keys):
+STRICT JSON SHAPE (no extras):
 {
   "valuation_low": number | null,
   "valuation_mid": number | null,
@@ -68,8 +40,8 @@ STRICT JSON SHAPE (only these keys):
 `;
 
 export function buildValuationUserPayload(input: Record<string, any>) {
-  const make = input?.vesselData?.make ?? input?.make ?? null;
-  const model = input?.vesselData?.model ?? input?.model ?? null;
+  const make = input?.vesselData?.make ?? input?.make ?? "";
+  const model = input?.vesselData?.model ?? input?.model ?? "";
   const year = input?.vesselData?.year ?? input?.year ?? null;
   const loaFt = input?.vesselData?.loaFt ?? input?.loaFt ?? null;
   const fuelType = input?.vesselData?.fuelType ?? input?.fuelType ?? null;
@@ -77,42 +49,54 @@ export function buildValuationUserPayload(input: Record<string, any>) {
   const condition = input?.vesselData?.condition ?? input?.condition ?? null;
   const region = input?.region ?? input?.market_region ?? "South Florida";
 
-  // --- Derived, non-numeric hints (no pricing logic) ---
-  const makeLc = String(make || "").toLowerCase();
-  const modelLc = String(model || "").toLowerCase();
-  const isCenterConsole =
-    /console|cc|freeman|valhalla|yellowfin|invincible|hcb|midnight|nor[-\s]?tech|seahunter/.test(makeLc + " " + modelLc);
+  const text = `${make} ${model}`.toLowerCase();
+
+  // --- Derived, label-only hints (no math) ---
+  const isCC = /(center\s*console|\bcc\b|freeman|valhalla|yellowfin|invincible|hcb|midnight|nor[-\s]?tech|intrepid|contender|seahunter|boston\s*whaler|everglades|cigarette|fountain|blackfin)/i.test(text);
+  const isSportfish = /(viking|bertram|hatteras|cabo|rampage|spencer|jarrett|merritt|convertible)/i.test(text);
+  const isMY = /(sunseeker|azimut|princess|ferretti|absolute|galeon|fairline|riva|monte\s*carlo)/i.test(text);
+  const isExpress = /(coupe|express|gran\s*turismo|predator(?!.*cc))/i.test(text);
+  const isTrawler = /(trawler|selene|kadey|nordhavn|grand\s*banks)/i.test(text);
+  const isSailMono = /(beneteau|jeanneau|hanse|swan|catalina|dufour|oyster).*sail/i.test(text);
+  const isSailCat = /(lagoon|fountaine|leopard).*cat/i.test(text);
+  const isPowerCat = /(power\s*cat|aquila|world\s*cat|pc\s*\d{2})/i.test(text);
+  const isRib = /(zodiac|rib|avon|walker\s*bay)/i.test(text);
+
+  const segment =
+    isCC ? "Center Console" :
+    isSportfish ? "Sportfish/Convertible" :
+    isMY ? "Motor Yacht/Flybridge" :
+    isExpress ? "Express/Coupe" :
+    isTrawler ? "Trawler" :
+    isSailMono ? "Sailing Monohull" :
+    isSailCat ? "Sailing Catamaran" :
+    isPowerCat ? "Power Catamaran" :
+    isRib ? "RIB/Inflatable" : "Other";
 
   const brandTier =
-    /(freeman|valhalla|invincible|yellowfin|hcb|midnight|nor[-\s]?tech)/.test(makeLc)
+    /(freeman|valhalla|hcb|midnight|nor[-\s]?tech|intrepid|yellowfin|invincible|boston\s*whaler|contender|seahunter|everglades|cigarette|fountain|blackfin)/i.test(text)
       ? "Premium"
-      : isCenterConsole ? "Mainstream-CC" : "Standard";
+      : /(sunseeker|azimut|princess|ferretti|riva|fairline|absolute|galeon)/i.test(text)
+      ? "Luxury"
+      : "Standard";
 
   const scarcity =
-    /(freeman)/.test(makeLc) ? "High"
-      : /(valhalla|hcb|midnight|nor[-\s]?tech)/.test(makeLc) ? "Medium"
-      : "Normal";
-
-  const segment = isCenterConsole ? "Center Console" : "Other";
-
-  const fields = {
-    make, model, year, loaFt, fuelType, hours, condition, region,
-    // Hints only — the model uses these to choose the correct band
-    segment,
-    brandTier,
-    scarcity
-  };
+    /(freeman)/i.test(text) ? "High" :
+    /(valhalla|hcb|midnight|nor[-\s]?tech|intrepid|yellowfin|invincible)/i.test(text) ? "Medium" :
+    "Normal";
 
   return {
     instruction: `
-Return STRICT JSON matching the shape above.
-- Compute valuation_low/mid/high and wholesale from the inputs and policy only (no examples).
-- Apply the Brand & Scarcity Policy using 'segment', 'brandTier', and 'scarcity'.
-- Keep wholesale within 55–65% of valuation_mid unless a strong reason is noted in "assumptions".
-- Choose Confidence (if you still expose it internally) but do not include it in prose unless specified.
-- Keep "assumptions" short; include one line if you down-bias a premium/rare brand despite favorable indicators.
+Use the fields & hints below with the policy above. Compute valuation_low/mid/high and wholesale (fast-cash) using market reasoning only.
+- Apply the Brand & Scarcity Policy ONLY when segment == "Center Console" AND brandTier == "Premium" AND scarcity in {"High","Medium"}.
+- Otherwise ignore that bias and follow the Global Valuation Policy.
+- Keep wholesale within 55–65% of valuation_mid unless a strong reason is added to "assumptions".
 - Echo inputs (including derived hints) in "inputs_echo".
+Return STRICT JSON only.
 `,
-    fields
+    fields: {
+      make, model, year, loaFt, fuelType, hours, condition, region,
+      segment, brandTier, scarcity
+    }
   };
 }

--- a/client/src/components/MetricCard.tsx
+++ b/client/src/components/MetricCard.tsx
@@ -1,9 +1,13 @@
-export function MetricCard({label,value}: {label: string, value?: number}){
-  const fmt=(n: number | undefined)=> n?.toLocaleString?.("en-US",{style:"currency",currency:"USD"}) ?? "—";
+interface MetricCardProps {
+  label: string;
+  value: string;
+}
+
+export function MetricCard({ label, value }: MetricCardProps) {
   return (
-    <div className="hp-card hp-metric">
-      <div className="hp-cap">{label}</div>
-      <div className="hp-val">{fmt(value)}</div>
+    <div className="rounded-xl border bg-card p-4 text-center shadow-sm">
+      <div className="text-sm font-medium text-muted-foreground">{label}</div>
+      <div className="mt-2 text-2xl font-semibold text-foreground">{value}</div>
     </div>
   );
 }

--- a/client/src/components/boat-form.tsx
+++ b/client/src/components/boat-form.tsx
@@ -219,38 +219,16 @@ export default function BoatForm({
           throw new Error(message);
         }
 
-        const floor10k = (value: number | null) =>
-          typeof value === "number" && Number.isFinite(value)
-            ? Math.floor(value / 10000) * 10000
-            : null;
-
-        const midFallbackValue =
-          normalizedResult.valuation_low !== null && normalizedResult.valuation_high !== null
-            ? Math.round((normalizedResult.valuation_low + normalizedResult.valuation_high) / 2)
-            : null;
-
-        const midBaseCandidate = normalizedResult.valuation_mid ?? midFallbackValue;
-        const mostLikelyValue =
-          midBaseCandidate ??
-          normalizedResult.valuation_high ??
-          normalizedResult.valuation_low ??
-          0;
-        const midBaseValue = midBaseCandidate ?? mostLikelyValue;
-        const lowValue = normalizedResult.valuation_low ?? mostLikelyValue;
-        const highValue = normalizedResult.valuation_high ?? mostLikelyValue;
-
-        const derivedWholesale =
-          normalizedResult.wholesale ?? floor10k(midBaseValue * 0.60);
-
-        const wholesaleValue = derivedWholesale ?? floor10k(mostLikelyValue * 0.60) ?? 0;
         const estimate = {
           id: generateId(),
-          low: lowValue,
-          mostLikely: mostLikelyValue,
-          high: highValue,
-          wholesale: wholesaleValue,
-          confidence: "Medium",
+          low: normalizedResult.valuation_low,
+          mostLikely: normalizedResult.valuation_mid,
+          high: normalizedResult.valuation_high,
+          wholesale: normalizedResult.wholesale,
           narrative: normalizedResult.narrative ?? "",
+          ...(normalizedResult.assumptions
+            ? { assumptions: normalizedResult.assumptions }
+            : {}),
           comps: [],
           isPremiumLead: false,
         };

--- a/client/src/components/valuation-results.tsx
+++ b/client/src/components/valuation-results.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { MetricCard } from "@/components/MetricCard";
 
 interface ValuationData {
   lead: {
@@ -19,21 +20,20 @@ interface ValuationData {
   };
   estimate: {
     id: string;
-    low: number;
-    mostLikely: number;
-    high: number;
-    wholesale: number;
-    confidence: string;
+    low: number | null;
+    mostLikely: number | null;
+    high: number | null;
+    wholesale: number | null;
     narrative: string;
-    comps: Array<{
+    assumptions?: string[];
+    comps?: Array<{
       title: string;
       ask: number;
       year: number;
       loa: number;
       region: string;
     }>;
-    isPremiumLead: boolean;
-    aiStatus?: string;
+    isPremiumLead?: boolean;
   };
 }
 
@@ -43,213 +43,57 @@ interface ValuationResultsProps {
   onEmailReport: () => void;
 }
 
+const fmt = (n?: number | null) =>
+  typeof n === "number"
+    ? n.toLocaleString("en-US", { maximumFractionDigits: 0 })
+    : "—";
+
 export default function ValuationResults({ data, onCallJames, onEmailReport }: ValuationResultsProps) {
-  const { lead, vessel, estimate } = data;
+  const { vessel, estimate } = data;
+
+  const lowValue = typeof estimate.low === "number" ? `$${fmt(estimate.low)}` : "—";
+  const midValue = typeof estimate.mostLikely === "number" ? `$${fmt(estimate.mostLikely)}` : "—";
+  const highValue = typeof estimate.high === "number" ? `$${fmt(estimate.high)}` : "—";
+  const wholesaleValue = typeof estimate.wholesale === "number" ? `~$${fmt(estimate.wholesale)}` : "—";
+  const narrative = estimate.narrative ?? "";
 
   return (
-    <div className="fade-in">
-      <Card className="shadow-lg border overflow-hidden">
-        {/* Results Header */}
-        <div className="gradient-bg text-white p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-2xl font-bold mb-2" data-testid="text-valuation-title">
-                Your Boat Valuation
-              </h2>
-              <p className="text-blue-100">Based on current market conditions and comparable sales</p>
-            </div>
-            <div className="text-right">
-              <div className="bg-white bg-opacity-20 rounded-lg px-3 py-1">
-                <span className="text-sm font-medium" data-testid="text-confidence">
-                  Confidence: {estimate.confidence}
-                </span>
-              </div>
-            </div>
+    <div className="max-w-5xl mx-auto px-4 space-y-6 md:space-y-8">
+      <Card className="border shadow-sm">
+        <CardHeader>
+          <h2 className="text-2xl font-semibold">Your Boat Valuation</h2>
+          <p className="text-sm text-muted-foreground">
+            Based on current market conditions for your
+            {vessel.year ? ` ${vessel.year}` : ""}
+            {` ${vessel.brand}`}
+            {vessel.model ? ` ${vessel.model}` : ""}
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6 md:space-y-8">
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <MetricCard label="Low" value={lowValue} />
+            <MetricCard label="Most Likely" value={midValue} />
+            <MetricCard label="High" value={highValue} />
+            <MetricCard label="Wholesale (Fast Cash)" value={wholesaleValue} />
           </div>
-        </div>
-
-        {/* Vessel Summary */}
-        <CardContent className="p-6 border-b">
-          <div className="grid md:grid-cols-2 gap-6">
-            <div>
-              <h3 className="text-lg font-semibold text-foreground mb-4">Vessel Summary</h3>
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Brand:</span>
-                  <span className="font-medium" data-testid="text-vessel-brand">{vessel.brand}</span>
-                </div>
-                {vessel.model && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Model:</span>
-                    <span className="font-medium" data-testid="text-vessel-model">{vessel.model}</span>
-                  </div>
-                )}
-                {vessel.year && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Year:</span>
-                    <span className="font-medium" data-testid="text-vessel-year">{vessel.year}</span>
-                  </div>
-                )}
-                {vessel.loaFt && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Length:</span>
-                    <span className="font-medium" data-testid="text-vessel-length">{vessel.loaFt}ft</span>
-                  </div>
-                )}
-                {vessel.fuelType && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Fuel Type:</span>
-                    <span className="font-medium" data-testid="text-vessel-fuel">
-                      {vessel.fuelType === 'gas' ? 'Gas' : 
-                       vessel.fuelType === 'diesel' ? 'Diesel' : 
-                       vessel.fuelType === 'unknown' ? 'Unknown' : vessel.fuelType}
-                    </span>
-                  </div>
-                )}
-                {vessel.hours !== null && vessel.hours !== undefined && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Hours:</span>
-                    <span className="font-medium" data-testid="text-vessel-hours">{vessel.hours.toLocaleString()}</span>
-                  </div>
-                )}
-                {vessel.condition && (
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Condition:</span>
-                    <span className="font-medium" data-testid="text-vessel-condition">
-                      {vessel.condition === 'very_good' ? 'Very Good' : 
-                       vessel.condition.charAt(0).toUpperCase() + vessel.condition.slice(1)}
-                    </span>
-                  </div>
-                )}
-              </div>
+          <div className="rounded-lg border bg-card p-6 shadow-sm">
+            <p className="text-muted-foreground leading-relaxed">{narrative}</p>
+          </div>
+          {estimate.assumptions && estimate.assumptions.length > 0 && (
+            <div className="rounded-lg border bg-muted/30 p-4">
+              <h3 className="text-sm font-semibold text-foreground mb-2">Key Assumptions</h3>
+              <ul className="list-disc pl-5 text-sm text-muted-foreground space-y-1">
+                {estimate.assumptions.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
             </div>
-            <div>
-              <h3 className="text-lg font-semibold text-foreground mb-4">Valuation Range</h3>
-              <div className="space-y-4">
-                <div className="text-center p-4 bg-primary bg-opacity-10 rounded-lg">
-                  <div className="text-sm text-white font-medium mb-1">Estimated Value</div>
-                  <div className="text-3xl font-bold text-white" data-testid="text-most-likely-value">
-                    ${estimate.mostLikely.toLocaleString()}
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4 text-sm">
-                  <div className="text-center p-3 bg-muted rounded-lg">
-                    <div className="text-muted-foreground mb-1">Low</div>
-                    <div className="font-semibold" data-testid="text-low-value">
-                      ${estimate.low.toLocaleString()}
-                    </div>
-                  </div>
-                  <div className="text-center p-3 bg-muted rounded-lg">
-                    <div className="text-muted-foreground mb-1">High</div>
-                    <div className="font-semibold" data-testid="text-high-value">
-                      ${estimate.high.toLocaleString()}
-                    </div>
-                  </div>
-                </div>
-                <div className="text-center p-3 bg-secondary rounded-lg">
-                  <div className="text-sm text-muted-foreground mb-1">Wholesale Estimate</div>
-                  <div className="font-semibold text-foreground" data-testid="text-wholesale-value">
-                    ${estimate.wholesale.toLocaleString()}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-
-        {/* Market Analysis */}
-        <CardContent className="p-6 border-b">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Market Analysis</h3>
-          <div className="prose prose-sm max-w-none">
-            <p className="text-muted-foreground leading-relaxed" data-testid="text-narrative">
-              {estimate.narrative}
-            </p>
-          </div>
-        </CardContent>
-
-        {/* Comparable Sales */}
-        <CardContent className="p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">Recent Comparable Sales</h3>
-          <div className="space-y-4">
-            {estimate.comps.map((comp, index) => (
-              <div 
-                key={index} 
-                className="flex items-center justify-between p-4 bg-muted rounded-lg"
-                data-testid={`comp-${index}`}
-              >
-                <div className="flex-1">
-                  <h4 className="font-semibold text-foreground" data-testid={`comp-title-${index}`}>
-                    {comp.title}
-                  </h4>
-                  <div className="text-sm text-muted-foreground mt-1">
-                    <span data-testid={`comp-details-${index}`}>
-                      {comp.year} • {comp.loa}ft • {comp.region}
-                    </span>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="font-bold text-lg text-foreground" data-testid={`comp-price-${index}`}>
-                    ${comp.ask.toLocaleString()}
-                  </div>
-                  <div className="text-xs text-muted-foreground">Asking Price</div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-
-        {/* Actions */}
-        <CardContent className="p-6 bg-muted">
-          <div className="flex flex-col md:flex-row gap-4">
-            <Button 
-              onClick={onCallJames}
-              className="flex-1 bg-primary hover:bg-primary/90 text-primary-foreground"
-              data-testid="button-call-james"
-            >
-              <i className="fas fa-phone mr-2" />
-              Call Us: (954) 541-0105
-            </Button>
-            <Button 
-              onClick={onEmailReport}
-              variant="secondary"
-              className="flex-1"
-              data-testid="button-email-report"
-            >
-              <i className="fas fa-envelope mr-2" />
+          )}
+          <div className="flex flex-col gap-3 md:flex-row">
+            <Button onClick={onCallJames} className="md:flex-1">Call Us: (954) 541-0105</Button>
+            <Button onClick={onEmailReport} variant="secondary" className="md:flex-1">
               Email Full Report
             </Button>
-          </div>
-          <div className="mt-4 text-center">
-            <p className="text-sm text-muted-foreground">
-              Questions about your valuation? Our expert team is standing by to help.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Email Confirmation */}
-      <Card className="mt-8 border-green-200 bg-green-50">
-        <CardContent className="p-6">
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              <i className="fas fa-check-circle text-green-500 text-xl" />
-            </div>
-            <div className="ml-3">
-              <h3 className="text-lg font-semibold text-green-800" data-testid="text-confirmation-title">
-                Valuation Report Generated!
-              </h3>
-              <p className="text-green-700 mt-1" data-testid="text-confirmation-message">
-                Your detailed valuation report for the {vessel.year} {vessel.brand} {vessel.model}{" "}
-                has been generated successfully. A comprehensive analysis including market trends 
-                and selling strategies will be sent to {" "}
-                <span className="font-semibold" data-testid="text-lead-email">james.jr@wavemarinegroup.com</span>{" "}
-                upon request.
-              </p>
-              <p className="text-sm text-green-600 mt-2">
-                <i className="fas fa-clock mr-1" />
-                Generated just now • Contact us for detailed market insights
-              </p>
-            </div>
           </div>
         </CardContent>
       </Card>

--- a/client/src/lib/valuation-result.ts
+++ b/client/src/lib/valuation-result.ts
@@ -116,13 +116,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function floor10k(n: number | null): number | null {
-  if (typeof n !== "number" || !Number.isFinite(n)) {
-    return null;
-  }
-  return Math.floor(n / 10000) * 10000;
-}
-
 /**
  * Normalizes valuation responses so the UI can rely on a consistent shape regardless of the backend version.
  * If the flat ValuationResult shape is present it is returned directly. Otherwise the function attempts to
@@ -161,18 +154,11 @@ export function normalizeValuationResponse(raw: unknown): ValuationResult | null
   const inputsFromRaw = extractInputsEcho(rawRecord);
   const inputs_echo = Object.keys(inputsFromData).length > 0 ? inputsFromData : inputsFromRaw;
 
-  const midFallback =
-    valuation_low !== null && valuation_high !== null
-      ? Math.round((valuation_low + valuation_high) / 2)
-      : null;
-  const midBase = valuation_mid ?? midFallback;
-  const computedWholesale = valuation_wholesale ?? floor10k(midBase !== null ? midBase * 0.60 : null);
-
   const candidate = {
     valuation_low,
     valuation_mid,
     valuation_high,
-    wholesale: computedWholesale,
+    wholesale: valuation_wholesale,
     narrative: narrative ?? null,
     assumptions: assumptions ?? null,
     inputs_echo,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { submitFormRateLimit, generalRateLimit } from "./middleware/rateLimit";
 import { openAIHealth } from "./utils/ai-utils";
-import { openai, OPENAI_MODEL } from "../backend/ai-utils";
+import { openai } from "../backend/ai-utils";
 import { VALUATION_SYSTEM_PROMPT, buildValuationUserPayload } from "../backend/prompts/valuation";
 import { ValuationResult } from "../backend/types";
 
@@ -14,21 +14,25 @@ export async function postValuation(req: Request, res: Response) {
       return res.status(502).json({ error: "AIUnavailable", detail: "Missing OPENAI_API_KEY" });
     }
 
+    const userPayload = buildValuationUserPayload(payload);
+    const model = process.env.OPENAI_MODEL || "gpt-4.1-mini";
+
     // (Optional debug) quick visibility in logs
     console.log("Valuation calling OpenAI", {
-      model: OPENAI_MODEL,
+      model,
       keyPresent: !!process.env.OPENAI_API_KEY,
     });
 
     const resp: any = await openai.responses.create({
-      model: OPENAI_MODEL,
+      model,
+      temperature: 0,
+      top_p: 1,
+      seed: 7,
+      response_format: { type: "json_object" },
       input: [
         { role: "system", content: VALUATION_SYSTEM_PROMPT },
-        { role: "user", content: JSON.stringify(buildValuationUserPayload(payload)) }
-      ],
-      text: { format: { type: "json_object" } },
-      temperature: 0.1,
-      top_p: 1
+        { role: "user", content: JSON.stringify(userPayload) }
+      ]
     } as any);
 
     const text = resp.output_text
@@ -46,9 +50,12 @@ export async function postValuation(req: Request, res: Response) {
       ai = {};
     }
 
-    // Scrub banned phrases
     if (ai && typeof ai.narrative === "string") {
       ai.narrative = ai.narrative
+        .replace(/Estimated Market Range:[^.]*\./gi, "")
+        .replace(/Most Likely:[^.]*\./gi, "")
+        .replace(/Wholesale:[^.]*\./gi, "")
+        .replace(/Confidence:\s*(Low|Medium|High)\.?/gi, "")
         .replace(/reduces value/gi, "")
         .replace(/limits pricing/gi, "")
         .replace(/\bissues\b/gi, "")
@@ -57,61 +64,35 @@ export async function postValuation(req: Request, res: Response) {
         .trim();
     }
 
-    // Clean formatting
-    const fmt = (n: number | null) => (
-      typeof n === "number"
-        ? n.toLocaleString("en-US", { maximumFractionDigits: 0 })
-        : "—"
-    );
-
-    const floor10k = (n: number | null) => (
-      typeof n === "number" && Number.isFinite(n)
-        ? Math.floor(n / 10000) * 10000
-        : null
-    );
-
-    const low = typeof ai?.valuation_low === "number" && Number.isFinite(ai.valuation_low)
+    const valuationLow = typeof ai?.valuation_low === "number" && Number.isFinite(ai.valuation_low)
       ? ai.valuation_low
       : null;
-    const mid = typeof ai?.valuation_mid === "number" && Number.isFinite(ai.valuation_mid)
+    const valuationMid = typeof ai?.valuation_mid === "number" && Number.isFinite(ai.valuation_mid)
       ? ai.valuation_mid
       : null;
-    const high = typeof ai?.valuation_high === "number" && Number.isFinite(ai.valuation_high)
+    const valuationHigh = typeof ai?.valuation_high === "number" && Number.isFinite(ai.valuation_high)
       ? ai.valuation_high
       : null;
+    const wholesale = typeof ai?.wholesale === "number" && Number.isFinite(ai.wholesale)
+      ? ai.wholesale
+      : null;
 
-    const midFallback = low !== null && high !== null ? Math.round((low + high) / 2) : null;
-    const midBase = mid ?? midFallback;
-    const wholesaleRaw = typeof midBase === "number" ? midBase * 0.60 : null;
-    const wholesale = floor10k(wholesaleRaw);
+    const assumptions = Array.isArray(ai?.assumptions)
+      ? ai.assumptions.filter((item: unknown): item is string => typeof item === "string")
+      : null;
 
-    const tokenLine =
-      ` Estimated Market Range: $${fmt(low)}–$${fmt(high)}.` +
-      ` Most Likely: $${fmt(midBase)}.` +
-      ` Wholesale: ~$${fmt(wholesale)}.` +
-      ` Confidence: ${ai?.confidence ?? "Medium"}.`;
-
-    // Remove any AI-generated token lines to avoid duplicates
-    ai.narrative = typeof ai.narrative === "string" ? ai.narrative : "";
-
-    ai.narrative = ai.narrative
-      .replace(/Estimated Market Range:[^.]*\./i, "")
-      .replace(/Most Likely:[^.]*\./i, "")
-      .replace(/Wholesale:[^.]*\./i, "")
-      .replace(/Confidence:[^.]*\./i, "")
-      .trim();
-
-    // Append clean final version
-    ai.narrative = (ai.narrative.endsWith(".") ? ai.narrative : ai.narrative + ".") + tokenLine;
+    const inputsEcho = ai && ai.inputs_echo && typeof ai.inputs_echo === "object" && !Array.isArray(ai.inputs_echo)
+      ? ai.inputs_echo
+      : userPayload.fields;
 
     const result: ValuationResult = {
-      valuation_low: low,
-      valuation_mid: mid,
-      valuation_high: high,
+      valuation_low: valuationLow,
+      valuation_mid: valuationMid,
+      valuation_high: valuationHigh,
       wholesale,
-      narrative: typeof ai.narrative === "string" ? ai.narrative : null,
-      assumptions: Array.isArray(ai.assumptions) ? ai.assumptions : null,
-      inputs_echo: payload
+      narrative: typeof ai.narrative === "string" && ai.narrative.length > 0 ? ai.narrative : null,
+      assumptions,
+      inputs_echo: inputsEcho
     };
 
     return res.json(result);


### PR DESCRIPTION
## Summary
- replace the valuation system prompt with segment-aware guardrails and scoped premium center-console bias
- make the valuation route deterministic with JSON responses and clean narrative output with no server-side math
- refresh the valuation UI to drop confidence, display AI numbers only, and support optional assumptions with new metric cards

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68c9bdafd72c83228cc40c1eda6dc4e1