### PR TITLE
fix: remove unsupported seed param from OpenAI call

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,7 +27,6 @@ export async function postValuation(req: Request, res: Response) {
       model,
       temperature: 0,
       top_p: 1,
-      seed: 7,
       text: { format: "json" },
       input: [
         { role: "system", content: VALUATION_SYSTEM_PROMPT },


### PR DESCRIPTION
## Summary
- remove the unsupported `seed` parameter from the valuation OpenAI Responses call while keeping other settings untouched

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c6329c608322ac74f684923b7db6