### PR TITLE
fix(api): Responses text.format must be an object { type: "json_object" }

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,7 +27,8 @@ export async function postValuation(req: Request, res: Response) {
       model,
       temperature: 0,
       top_p: 1,
-      text: { format: "json" },
+      modalities: ["text"],
+      text: { format: { type: "json_object" } },
       input: [
         { role: "system", content: VALUATION_SYSTEM_PROMPT },
         { role: "user", content: JSON.stringify(userPayload) }


### PR DESCRIPTION
## Summary
- update the OpenAI Responses API request to use the new JSON mode shape with modalities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c7f5b2f8832281f38fd335296b2d