### PR TITLE
Adjust vessel make/model validation per step

### DIFF
--- a/client/src/lib/validation.ts
+++ b/client/src/lib/validation.ts
@@ -8,8 +8,8 @@ const vesselSchema = z.object({
   makeModel: z.string().optional(),
   model: z
     .string()
-    .trim()
-    .min(1, "Model must be provided"),
+    .optional()
+    .transform((value) => (typeof value === "string" ? value.trim() : value)),
 });
 
 export const leadVesselValidationSchema = z.object({


### PR DESCRIPTION
## Summary
- gate the first step submission behind targeted contact and vessel make validation and set the temporary makeModel shim
- ensure the second step validates the vessel model and other vessel fields before continuing
- relax the shared schema so the model field is optional until the second step requires it

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d58b2dbb0c832287ce3cbf0f3d8120