### PR TITLE
Update condition card titles

### DIFF
--- a/client/src/components/boat-form.tsx
+++ b/client/src/components/boat-form.tsx
@@ -941,7 +941,7 @@ export default function BoatForm({
                       name="condition.exteriorScore"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel className="hp-label">Overall Exterior Condition (1–10)</FormLabel>
+                          <FormLabel className="hp-label">Overall Exterior Condition</FormLabel>
                           <FormControl>
                             <div>
                               <div className="flex justify-between text-xs text-muted-foreground mb-2">
@@ -990,7 +990,7 @@ export default function BoatForm({
                       name="condition.interiorScore"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel className="hp-label">Overall Interior Condition (1–10)</FormLabel>
+                          <FormLabel className="hp-label">Overall Interior Condition</FormLabel>
                           <FormControl>
                             <div>
                               <div className="flex justify-between text-xs text-muted-foreground mb-2">


### PR DESCRIPTION
## Summary
- adjust the exterior and interior condition card titles to remove the explicit "(1–10)" suffix while leaving the chips unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a4cd040c8322a125f72d8fbff839