### PR TITLE
Update results labels to use Replacement Cost wording

### DIFF
--- a/client/src/features/results/ResultsCard.tsx
+++ b/client/src/features/results/ResultsCard.tsx
@@ -1,4 +1,5 @@
 import MinimalGauge from "./MinimalGauge";
+import { LABELS } from "./labels";
 
 export default function ResultsCard({
   wholesale,
@@ -14,7 +15,7 @@ export default function ResultsCard({
               Valuation Results
             </h2>
             <p className="mt-1 text-sm text-slate-500">
-              Range from Wholesale to Replacement Cost. Needle marks Market Value.
+              Range from {LABELS.wholesale} to {LABELS.replacement}. Needle marks {LABELS.market}.
             </p>
           </div>
 
@@ -26,16 +27,16 @@ export default function ResultsCard({
               size={420}
               trackWidth={18}
               valueWidth={18}
-              ariaLabel="Valuation gauge. Needle indicates Market Value."
+              ariaLabel={`Valuation gauge. Needle indicates ${LABELS.market}.`}
             />
           </div>
         </div>
 
         {/* Show values ONLY here */}
         <div className="grid md:grid-cols-3 gap-4 p-4 md:p-6 border-t border-slate-100">
-          <ValueTile label="Wholesale" value={wholesale} testId="wholesale-tile" />
-          <ValueTile label="Market Value" value={market} emphasis testId="market-tile" />
-          <ValueTile label="Replacement Cost" value={replacement} testId="replacement-tile" />
+          <ValueTile label={LABELS.wholesale} value={wholesale} testId="wholesale-tile" />
+          <ValueTile label={LABELS.market} value={market} emphasis testId="market-tile" />
+          <ValueTile label={LABELS.replacement} value={replacement} testId="replacement-tile" />
         </div>
       </div>
     </div>

--- a/client/src/features/results/ValuationGauge.tsx
+++ b/client/src/features/results/ValuationGauge.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { LABELS } from "./labels";
+
 type ValuationGaugeProps = {
   wholesale: number;
   market: number;
@@ -74,7 +76,7 @@ export default function ValuationGauge({
   const needleX = cx + needleInnerRadius * Math.cos(needleAngle);
   const needleY = cy + needleInnerRadius * Math.sin(needleAngle);
 
-  const label = `${ariaLabel}. Wholesale ${formatUSD(safeWholesale)}. Market ${formatUSD(clampedMarket)}. Replacement ${formatUSD(safeReplacement)}.`;
+  const label = `${ariaLabel}. ${LABELS.wholesale} ${formatUSD(safeWholesale)}. ${LABELS.market} ${formatUSD(clampedMarket)}. ${LABELS.replacement} ${formatUSD(safeReplacement)}.`;
 
   return (
     <div className="w-full flex justify-center">

--- a/client/src/features/results/labels.ts
+++ b/client/src/features/results/labels.ts
@@ -1,0 +1,6 @@
+export const LABELS = {
+  wholesale: "Wholesale",
+  market: "Market Value",
+  replacement: "Replacement Cost",
+} as const;
+export type LabelKey = keyof typeof LABELS;


### PR DESCRIPTION
## Summary
- add a shared results label map for wholesale, market value, and replacement cost text
- update the results card and gauge to source labels from the shared constants and display “Replacement Cost” wording

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6e00ea8548322a845d8e3af025610