### PR TITLE
Polish results gauge spacing and add visual guard

### DIFF
--- a/client/src/features/results/ResultsCard.tsx
+++ b/client/src/features/results/ResultsCard.tsx
@@ -1,21 +1,76 @@
+import * as React from "react";
+
 import ProGauge from "./ProGauge";
 import { LABELS } from "./labels";
 import { formatUSD } from "./format";
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
 
 export default function ResultsCard({
   wholesale,
   market,
   replacement,
-}: { wholesale: number; market: number; replacement: number; }) {
-  const gaugeWidth = "min(100%, clamp(340px, 60vw, 640px))";
+}: {
+  wholesale: number;
+  market: number;
+  replacement: number;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [width, setWidth] = React.useState(420);
+  const [preview, setPreview] = React.useState<number | undefined>(undefined);
+  const handleScrub = React.useCallback((next?: number) => {
+    setPreview(next);
+  }, []);
+
+  React.useEffect(() => {
+    if (!ref.current || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setWidth((prev) => {
+          const next = entry.contentRect.width;
+          if (Math.abs(prev - next) < 0.5) {
+            return prev;
+          }
+          return next;
+        });
+      }
+    });
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
   const safeWholesale = Number.isFinite(wholesale) ? wholesale : 0;
-  const safeReplacement = Number.isFinite(replacement) ? replacement : safeWholesale + 1;
-  const minValue = Math.min(safeWholesale, safeReplacement);
-  const maxValue = Math.max(safeWholesale, safeReplacement);
-  const span = maxValue - minValue || 1;
-  const fallbackMarket = minValue + span / 2;
-  const safeMarket = Number.isFinite(market) ? market : fallbackMarket;
-  const clampedMarket = Math.min(Math.max(safeMarket, minValue), maxValue);
+  const safeReplacement = Number.isFinite(replacement)
+    ? replacement
+    : safeWholesale + 1;
+  const safeMarket = Number.isFinite(market)
+    ? market
+    : safeWholesale + (safeReplacement - safeWholesale) / 2;
+
+  let min = Math.min(safeWholesale, safeReplacement, safeMarket);
+  let max = Math.max(safeWholesale, safeReplacement, safeMarket);
+  if (min === max) {
+    min -= 1;
+    max += 1;
+  }
+
+  const clampedMarket = clamp(safeMarket, min, max);
+  const points = React.useMemo(
+    () => [
+      { id: "wholesale", label: LABELS.wholesale, value: safeWholesale },
+      { id: "market", label: LABELS.market, value: clampedMarket },
+      { id: "replacement", label: LABELS.replacement, value: safeReplacement },
+    ],
+    [clampedMarket, safeReplacement, safeWholesale],
+  );
+
+  const gaugeSize = clamp(width, 340, 640);
+  const displayValue = clamp(preview ?? clampedMarket, min, max);
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 md:px-6">
@@ -30,46 +85,69 @@ export default function ResultsCard({
             </p>
           </div>
 
-          <div className="flex justify-center">
-            <div className="relative flex w-full justify-center" style={{ width: gaugeWidth }}>
-              <ProGauge
-                wholesale={wholesale}
-                market={market}
-                replacement={replacement}
-                ariaLabel={`Valuation gauge. Needle indicates ${LABELS.market}.`}
-              />
+          {/* Gauge */}
+          <div ref={ref} className="flex justify-center px-2">
+            <ProGauge
+              min={min}
+              max={max}
+              value={clampedMarket}
+              points={points}
+              size={gaugeSize}
+              trackWidth={16}
+              valueWidth={16}
+              onScrub={handleScrub}
+              ariaLabel="Valuation gauge. Needle indicates Market Value; hover or use arrow keys to preview."
+            />
+          </div>
 
-              <div
-                className="pointer-events-none absolute left-1/2 top-[98%] -translate-x-1/2 -translate-y-1/2"
-                aria-live="polite"
-                aria-atomic="true"
+          <div className="relative flex justify-center">
+            <div
+              className="mt-[-10px] mb-2 inline-flex max-w-full items-center gap-3 rounded-2xl bg-white px-6 py-4 shadow-md ring-1 ring-slate-200"
+              style={{ minHeight: 56 }}
+              data-testid="market-tile"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              <span className="shrink-0 text-xs uppercase tracking-wide text-slate-500">
+                Market Value
+              </span>
+              <span
+                className="truncate text-3xl font-semibold text-slate-900 tabular-nums md:text-4xl"
+                title={formatUSD(displayValue)}
+                aria-label={formatUSD(displayValue)}
               >
-                <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-900 shadow-md">
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                    {LABELS.market}
-                  </span>
-                  <span className="tabular-nums text-lg font-semibold text-slate-900">
-                    {formatUSD(clampedMarket)}
-                  </span>
-                </div>
-              </div>
+                {formatUSD(displayValue)}
+              </span>
             </div>
           </div>
         </div>
 
-        <div className="border-t border-slate-100 px-6 pb-8 pt-8 md:px-10">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <ValueTile label={LABELS.wholesale} value={safeWholesale} testId="wholesale-tile" />
-            <ValueTile label={LABELS.replacement} value={safeReplacement} testId="replacement-tile" />
-          </div>
+        {/* Divider + support tiles (no stray “Market Value” chip below) */}
+        <div className="grid gap-4 border-t border-slate-100 p-4 pt-6 md:grid-cols-2 md:p-6">
+          <ValueTile
+            label={LABELS.wholesale}
+            value={safeWholesale}
+            testId="wholesale-tile"
+          />
+          <ValueTile
+            label={LABELS.replacement}
+            value={safeReplacement}
+            testId="replacement-tile"
+          />
         </div>
       </div>
     </div>
   );
 }
 
-function ValueTile({ label, value, testId }:{
-  label: string; value: number; testId?: string;
+function ValueTile({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: number;
+  testId?: string;
 }) {
   return (
     <div
@@ -77,7 +155,7 @@ function ValueTile({ label, value, testId }:{
       className="rounded-xl border border-slate-200 bg-slate-50/70 p-5 shadow-sm"
     >
       <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
-      <div className="mt-2 text-2xl md:text-3xl font-semibold text-slate-900 tabular-nums">
+      <div className="mt-2 text-2xl font-semibold text-slate-900 tabular-nums md:text-3xl">
         {formatUSD(value)}
       </div>
     </div>

--- a/tests/valuation-results.visual.spec.ts
+++ b/tests/valuation-results.visual.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test("Results card visual snapshot", async ({ page }) => {
+  await page.goto(
+    "/boat-valuation?wholesale=990000&market=1700000&replacement=2295000",
+  );
+  await page.waitForTimeout(200);
+  const card = page
+    .locator('[data-testid="market-tile"]')
+    .locator("xpath=ancestor::div[contains(@class,'rounded-2xl')][1]");
+  await expect(card).toBeVisible();
+  await expect(card).toHaveScreenshot("results-card.png", {
+    maxDiffPixelRatio: 0.02,
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild ProGauge with padded arc geometry, thicker stroke, clamped labels, slider-style interactivity, pointer cursor polish, and reduced-motion aware label rendering
- adjust ResultsCard to feed the gauge via a clamped resize observer, float a single detached Market Value pill, and keep truncation accessible
- add a Playwright visual snapshot to guard the valuation results card styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6eefa56308322ac0443aaa1109008