### PR TITLE
Fix PremiumGauge orientation

### DIFF
--- a/client/src/features/results/PremiumGauge.tsx
+++ b/client/src/features/results/PremiumGauge.tsx
@@ -42,7 +42,7 @@ export default function PremiumGauge({
   const startA = Math.PI - PAD;
   const endA   = PAD;
   const angle  = (u:number) => startA + (endA - startA) * u;
-  const xy     = (a:number, rad:number) => ({ x: cx + rad*Math.cos(a), y: cy + rad*Math.sin(a) });
+  const xy     = (a:number, rad:number) => ({ x: cx + rad*Math.cos(a), y: cy - rad*Math.sin(a) });
 
   const arcPath = (u0:number, u1:number) => {
     const a0 = angle(Math.max(0, Math.min(1, u0)));


### PR DESCRIPTION
## Summary
- flip the PremiumGauge polar coordinate helper so the arc renders right-side up

## Testing
- npm run check --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d862d341688322920c460a1f3f2fdb