### PR TITLE
Refine mobile gauge width scaling

### DIFF
--- a/client/src/features/results/ResultsCard.tsx
+++ b/client/src/features/results/ResultsCard.tsx
@@ -5,11 +5,18 @@ import { formatUSD } from "./format";
 
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
 
-function useContainerWidth(min = 320, max = 640, pct = 0.86) {
+function useContainerWidth(min = 260, max = 640) {
   const ref = React.useRef<HTMLDivElement>(null);
   const clamp = React.useCallback(
-    (cw: number) => Math.round(Math.max(min, Math.min(max, cw * pct))),
-    [min, max, pct],
+    (cw: number) => {
+      const isVeryCompact = cw < 360;
+      const isCompact = !isVeryCompact && cw < 440;
+      const pct = isVeryCompact ? 0.56 : isCompact ? 0.68 : 0.86;
+      const targetMin = isVeryCompact ? 192 : isCompact ? 224 : min;
+      const target = cw * pct;
+      return Math.round(Math.max(targetMin, Math.min(max, target)));
+    },
+    [max, min],
   );
 
   const [w, setW] = React.useState<number>(() => {


### PR DESCRIPTION
## Summary
- tune the results gauge width clamp so very small screens shrink the dial further

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d9a9e89ebc83229032183e439beaed